### PR TITLE
Add counselor dashboard folder with README and LICENSE

### DIFF
--- a/dashboard/LICENSE.md
+++ b/dashboard/LICENSE.md
@@ -1,0 +1,18 @@
+# Repository Access & Governance
+
+**Repository Name:** careerday
+**Course/Quarter:** [Course Name / Quarter]
+**Team Members:** [List team members]
+**Project Sponsor:** CareerDayy
+
+1. **Ownership:** The student project team maintains this repository as part of their coursework. The work contributes to an exploratory project sponsored by CareerDayy.
+
+2. **Visibility:** The repository is private and is not publicly accessible.
+
+3. **Access Control:** Collaborator access is limited to the student team members and course staff (e.g., instructors or TAs) as needed for the course.
+
+4. **Post-Quarter Plan:** At the conclusion of the course, relevant components or learnings from this repository may be incorporated into CareerDayy's internal development repositories. Access permissions may be updated accordingly.
+
+5. **Sponsorship:** CareerDayy is serving as the external project sponsor. The sponsor does not currently have access to the repository during the academic quarter but may be granted access afterward if needed for integration or continued development.
+
+6. **Transferability:** This repository will remain associated with the student project team and will preserve the original commit history and contributor records.

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,20 @@
+# CareerDay — Counselor Dashboard
+
+## Repository Access & Governance
+
+**Repository Name:** careerday
+**Course/Quarter:** [Course Name / Quarter]
+**Team Members:** [List team members]
+**Project Sponsor:** CareerDayy
+
+1. **Ownership:** The student project team maintains this repository as part of their coursework. The work contributes to an exploratory project sponsored by CareerDayy.
+
+2. **Visibility:** The repository is private and is not publicly accessible.
+
+3. **Access Control:** Collaborator access is limited to the student team members and course staff (e.g., instructors or TAs) as needed for the course.
+
+4. **Post-Quarter Plan:** At the conclusion of the course, relevant components or learnings from this repository may be incorporated into CareerDayy's internal development repositories. Access permissions may be updated accordingly.
+
+5. **Sponsorship:** CareerDayy is serving as the external project sponsor. The sponsor does not currently have access to the repository during the academic quarter but may be granted access afterward if needed for integration or continued development.
+
+6. **Transferability:** This repository will remain associated with the student project team and will preserve the original commit history and contributor records.


### PR DESCRIPTION
Initializes dashboard/ with repository governance and access control documentation per CareerDayy sponsor requirements. Root README is preserved.